### PR TITLE
bump rusty_v8 to 0.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ lto = "off"
 
 [dependencies]
 # V8
-v8 = "0.74"
+v8 = "0.90"
 # JSON
 serde = { version = "1.0", features = ["derive"] }
 serde_jsonrc = "0.1"


### PR DESCRIPTION
Hadn't done this previously because I was working with an older version of rust at the start of the project.